### PR TITLE
Adjust Picture form guide to Rails5.1 generated view code

### DIFF
--- a/source/localizable/guides/app/picture-uploads.en.html.markdown.haml
+++ b/source/localizable/guides/app/picture-uploads.en.html.markdown.haml
@@ -46,14 +46,14 @@ Open `app/views/ideas/_form.html.erb` and change
 
 = preserve do 
   - code("erb") do
-    <%= f.text_field :picture %>
+    <%= form.text_field :picture, id: :idea_picture %>
 
 to
 
 
 = preserve do 
   - code("erb") do
-    <%= f.file_field :picture %>
+    <%= form.file_field :picture, id: :idea_picture %>
 
 Sometimes, you might get an *TypeError: can't cast ActionDispatch::Http::UploadedFile to string*.
 
@@ -61,13 +61,13 @@ If this happens, in file `app/views/ideas/_form.html.erb` change the line
 
 = preserve do
   - code("erb") do
-    <%= form_for(@idea) do |f| %>
+    <%= form_with(model: idea, local: true) do |form| %>
 
 to
 
 = preserve do
   - code("erb") do
-    <%= form_for @idea, :html => {:multipart => true} do |f| %>
+    <%= form_with(model: idea, local: true, multipart: true) do |form| %>
 
 
 In your browser, add new idea with a picture. When you upload a picture it doesn't look nice because it only shows a path to the file, so let's fix that.

--- a/source/localizable/guides/app/picture-uploads.he.html.markdown.haml
+++ b/source/localizable/guides/app/picture-uploads.he.html.markdown.haml
@@ -50,14 +50,14 @@ title: הוספת אפשרות להעלאת תמונות
 
 = preserve do 
   - code("erb") do
-    <%= f.text_field :picture %>
+    <%= form.text_field :picture, id: :idea_picture %>
 
 ל- 
 
 
 = preserve do 
   - code("erb") do
-    <%= f.file_field :picture %>
+    <%= form.file_field :picture, id: :idea_picture %>
 
 %br
 לפעמים את יכולה להיתקל בשגיאה הבאה: *TypeError: can't cast ActionDispatch::Http::UploadedFile to string*
@@ -66,13 +66,13 @@ title: הוספת אפשרות להעלאת תמונות
 
 = preserve do
   - code("erb") do
-    <%= form_for(@idea) do |f| %>
+    <%= form_with(model: idea, local: true) do |form| %>
 
 ל-
 
 = preserve do
   - code("erb") do
-    <%= form_for @idea, :html => {:multipart => true} do |f| %>
+    <%= form_with(model: idea, local: true, multipart: true) do |form| %>
 
 %br
 בדפדפן שלך, הוסיפי רעיון חדש עם תמונה. כשאת מעלה תמונה היא לא נראית כל כך טוב כי היא מציגה רק את הנתיב אל קובץ התמונה, אז בואי נתקן זאת.


### PR DESCRIPTION
The Installation guides do not specify a rails version:
`gem install rails --no-document`

Therefore the new people will install rails 5.1 (as of today).
One of the view changes was the introduction of `form_with` instead of `form_for`:
https://github.com/rails/rails/issues/25197

I updated both the 'replace the following code' sections as well as the edit code to
follow the new helper standards. (using the variable `form` instead of `f` \o/)